### PR TITLE
Disable legacy client authentication method (Tfsec GCP008)

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -82,6 +82,11 @@ resource "google_container_cluster" "cluster" {
     }
   }
 
+  master_auth {
+	    username = ""
+	    password = ""
+	}
+
   # Stackdriver
   logging_service    = var.logging_service ? "logging.googleapis.com/kubernetes" : "none"
   monitoring_service = var.monitoring_service ? "monitoring.googleapis.com/kubernetes" : "none"


### PR DESCRIPTION
https://tfsec.dev/docs/google/GCP008/

Signed-off-by: Nicolas Lamirault <nicolas.lamirault@gmail.com>